### PR TITLE
Make the main README framework agnostic and add support for Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # e2e Testing Workshop
 
-In this workshop you will learn how to write your first e2e tests with Selenium.
-We will test a "real" website, making sure it works and keeps working as expected.
+In this workshop you will learn how to write some basic end to end tests (often called e2e tests).
+You will test a "real" website, making sure it works as expected and keeps working when some new features are added.
 
 
 ## The Testing Pyramid
@@ -28,7 +28,8 @@ The idea of the Testing Pyramid is to find the right balance between all types o
 
 ## What are we going to do in this workshop?
 
-In this workshop we will work in small teams to create a small e2e test suite with Selenium Webdriver.
+In this workshop we will work in small teams to create a small e2e test suite with a test framework.
+*If you are doing this on your own, please feel welcome too.*
 
 ### Team Work!
 
@@ -38,14 +39,17 @@ One team member will be the "driver" writing the code. All the other team member
 Take turns being the "driver". If you don't feel comfortable typing, you don't have to.
 There are also other ways to organize your team: Someone has to look at the documentation, someone should have the browser inspector open...
 
-### What is Selenium?
+### Test Frameworks
 
-Selenium is a tool to automate and control browsers 🤖. It's main use case is testing, but it can also be used to automate tasks.
-The Selenium "family" consists of several different tools to help with the creation and execution of tests, for example an IDE.
-What we will be using today is **Selenium Webdriver**, a collection of binding for different programming languages that allow us to interact with the browser.
-This means we can use any of the supported programming languages and easily control the browser.
+This workshop is built in a modular way to work with multiple test frameworks.
+We have templates and some basic info to help you get started available for the following frameworks:
 
-We will use this to define some user flows on our website - and then use a testing library to check if the results are as expected.
+- [Selenium](./frameworks/Selenium.md)
+- [Playwright](./frameworks/Playwright.md)
+
+If you want to use something else, please feel free to do so, too! 
+You will have to figure out the setup for yourself, but we are sure that you can do it.
+
 
 ### The Workshop Scenario
 
@@ -53,70 +57,65 @@ During this workshop, you will take on the role of the QA (Quality Assurance) te
 [Instacat](https://www.instacat.app) allows cats to share their cutest pictures with the world and collect likes 💜.
 
 Your job is to work through a list of test cases that have been defined by the product team.
-Each test cases describes a different user flow that uses a feature of your product.
+Each test cases describes a different user flow based on a feature of your product.
 
-One main reason that we write tests is to make sure new features or changes didn't break existing functionality.
+One main reason to write tests is to make sure new features or changes don't break existing functionality.
 This means you will run your tests against different "releases" of the instacat website - simulated by different versions.
 The instructions below will tell you when a new version is released and you should change the URL you are using in your tests!
 
 > We suggest that you start off the workshop by getting to know your new team a little!
 > Tell everyone who you are, what your experience is with coding and testing and about a cat in your life!
 
-## Setup
+## Setup your test framework and test repo
 
-Select the template for your programming language of choice and create your own repo from:
-- **Javascript**: [Javascript Selenium Template](https://github.com/wwcode-berlin-hackevenings/selenium-javascript-template)
-- **Python**: [Python Selenium Template](https://github.com/wwcode-berlin-hackevenings/selenium-python-template)
+After you have picked you test framework, you can select the template for the language you want to use (if there are multiple available). 
+A list of available template can be found in the [section on the different test frameworks](#test-frameworks). Each template comes with setup instructions that will guide you through the process of setting up your repository where your new tests will go.
 
-Follow the instructions in the template repo to setup your local enviroment to be able to run the tests.
-If that does not work, the (Javascript) repo also has a GitHub Action workflow setup to run the tests as an Action.
-This is less fun though, because you don't get to see the browser automation in action!
-
-As soon as you are able to run the example test, you are ready to proceed to the next steps!
-The template repo also contains links to the Selenium documentation for your language of choice and for the test framework.
-
-**Some additional links:**
-- [MDN: Document Query Selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) - how to locate elements inside a website?
-- [Selenium Main Website](https://www.selenium.dev/)
-- [Guide to Browser Manipulation with Selenium](https://www.selenium.dev/documentation/en/webdriver/browser_manipulation/) - examples for different languages
+Each template also comes with an example test case and as soon as you are able to run this test case, you are ready to proceed to the next step.
 
 > Make sure your team has at least one person who can run the example test successfully and can also share their screen. If that is all set up, you are good to proceed to the next step!
 > We recommend you also make sure everyone on your team understands what is happening in the example test before you start writing your own!
 
+
+*If you are not using one of the languages and frameworks where we have a template available for you, you need to figure out the setup on your own. Usually the getting started documentation of a framework should be a good starting point to help you set up a new repository for your test cases and then install all the dependencies and get the test runner to run.*
+
+
 ## The Test Cases
 
-We have described a few test cases below, starting from very basic with no interactions and increasing in complexity.
-Feel free to go through them one by one or skip ahead!
+Below you will find the test cases that the product team has handed over to you, the QA team. 
+It starts with a very basic test with no interactions and but the complexity increases over time.
+Feel free to go through them one by one or skip ahead if you already have experience with e2e tests.
 
 
 ### Smoke Test: Verify the page loads
 
 E2e tests can become very complex and implement multi-step user interactions. 
 But usually you start with the basics: 
-The first case in every test suite should be a very simple test to verify that your page even loads at all (or that your test suite is running properly and the tests can access the page).
+The first case in every test suite should be a very simple test to verify that your page even loads at all (or that your test suite is running properly and the tests can access the page). This is often called a "smoke test".
 
-1. Use selenium to navigate to the Instacat website https://www.instacat.app
-2. Verify that anything is loading: You can for example select an appropriate element with selenium and check if it exists on the website using the testing library
+1. Use the tools provided by your test framework to navigate to the Instacat website https://www.instacat.app
+2. Verify that anything is loading at all: You can for example select an appropriate element and check if it exists on the website using the testing library
 
 > Run your new test case and see if it is successful (green)
 
 Congratulations! You have written your first test! 🙌
 
  💡 **Tips**
-- Look for the "get" method of the webdriver class to navigate to a URL
 - Your test can check for the existence of a certain element on the page, but there are also other options available. 
 - The browser dev tools with the inspector are your best friends 👫
+-  *Selenium:* Look for the "get" method of the webdriver class to navigate to a URL
+
 
 ### Check basic elements
 
 In this test case we want to look for specific HTML elements that should always be present on our website.
 
-1. Use selenium to navigate to the Instacat website
-2. Check if the h1 element (the headline "Instacat") exists on the page (use selenium to select it and the testing library to assert that it exists)
+1. Navigate to the Instacat website
+2. Check if the h1 element (the headline "Instacat") exists on the page
 3. Bonus: Check if there are any images on the page (we expect at least one image)
 4. Bonus: Check if the title meta tag is set correctly (we expect it to be "Instacat")
 
-> Run your test against the first version of the website from the previous test case
+> Run your test case
 
 If everything is green, congratulations again - you already finished 2 test cases!
 
@@ -130,45 +129,45 @@ If everything is green, congratulations again - you already finished 2 test case
   
   In this case, the only thing that changed are some CSS classes. If you used those to find the elements, your test might fail, even though the functionality of the site is unchanged.
 Depending on the project it can be a bad choice to use CSS classnames as selectors, if those classes might change frequently. 
-  A good way to select an element is a special data-test-id attribute (when it is available).
+  A good way to select an element is a special data-test-id attribute (when it is available) or the visible content.
 </details>
 
 
  💡 **Tips**
 - You might want to extract the URL to a variable so you don't have to change it for all your test cases after each deployment.
-- You can use the find element function to look for specific HTML elements on a page
-- There is a special function to check the value of the page title
+- *Selenium*: You can use the find element function to look for specific HTML elements on a page
+- *Selenium*: There is a special function to check the value of the page title
 
 ### Test the like feature
 
 All that the cats of Instacat want are likes! The like feature is really important, so we want to be sure it works.
 Write a test case where the like button is clicked and we check that the like counter has in fact increased.
 
-1. Navigate to the Instacat website using selenium
-2. Find the like counter (of any cat) with selenium and store its value
+1. Navigate to the Instacat website
+2. Find the like counter (of any cat) and store its value
 3. Find the like button (of the same cat!)
-4. Click the like button using selenium
+4. Click the like button
 5. Check the value of the like counter again - is it higher than before?
 
-> Run the test against the previous version of instacat https://v2.instacat.app/
+> Run the test against version 2 of instacat https://v2.instacat.app/
 
 If everything is green, we can be confident that our test suite will alert us when a change break this core feature of Instacat!
 
-> Imagine that another deployment happened, so you need to run your tests against the new version https://v3.instacat.app/ to verify that everything still works
+> Imagine that another deployment happened, so you need to run your tests against version 3 https://v3.instacat.app/ to verify that everything still works.
 
 
 <details> 
   <summary><i>Why is my test failing now?</i> </summary>
 Sometimes tests fail because there is a bug 🐞 in our software - this is where they shine and where we want them to fail! It gives us a chance to fix the bug before it goes to production and affects our fluffy users.
   
-  In this version, a bug was introduced to the like feature - you should be able to see it easily when you do a manual test.
+  In this version, a bug was introduced to the like feature - you should be able to see it easily when you do a manual test run of the feature.
   
-  So in this case the failing test was a good thing! It alerted us to a bug in the software that we can fix now.
+  So in this case the failing test was a good thing! It alerted us to a bug in the software that we can go and fix now.
 </details>
 
 
  💡 **Tips**
-- If you have found an element, you get back a Web Element: This object exposes different methods to allow you to interact with it.
+- *Selenium:* If you have found an element, you get back a Web Element: This object exposes different methods to allow you to interact with it.
 
 ----
 ## Bonus Exercises
@@ -180,16 +179,16 @@ Congratulations, you were really fast! Here are a few bonus cases if you want to
 The page footer shows a Copyright notice.
 Make sure it is showing the current year and is not outdated!
 
-> Run your test against the previous version 3 and see what happens (you can probably tell what happens from looking at the website...)
+> Run your test against version 3 and see what happens (you can probably tell what happens from looking at the website...)
 
 <details> 
   <summary><i>Why is my test failing now?</i></summary>
 You found another bug: The date was from last year. Again your test suite saves the day!
 </details>
 
-> Your tests found two bugs already. Luckily the developers have deployed a new version that fixes both those issues: https://v4.instacat.app/  
+> Your tests found two bugs already. Luckily the developers have deployed version 4 that fixes both those issues: https://v4.instacat.app/  
 
-Your tests should be green again.
+Your tests should be green again when you run them against v4.
 
 ### Test the adding cats feature (complex)
 
@@ -205,5 +204,5 @@ Wait until the new entry has been added to the page and check if your new cat is
 
 Users can flag inappropriate content - anything that is not a cat. Instacat is just for cats after all!
 If the "Not a Cat" button is clicked, the questionable entry should be removed from the site.
-Write a test case for the whole flow of clicking the button and checking that entry is gone afterwards.
+Write a test case for the whole flow of clicking the button for a cat and checking that it is gone afterwards.
 

--- a/frameworks/Playwright.md
+++ b/frameworks/Playwright.md
@@ -1,0 +1,26 @@
+# Playwright
+
+
+## What is Playwright?
+
+[Playwright](https://playwright.dev/) is a test framework that was built for end to end testing. It supports different operating systems and browsers and provides APIs for different programming languages.
+It has some convenience features built in which makes it a popular choice even though it is a relatively new framework. 
+It brings its own library for assertions which are built specficially for testing web sites.
+
+Compared to other framework it can also overcome some of the limits and run tests across different tabs or users.
+
+## Templates for Playwright
+
+The following templates are available for writing e2e tests in different languages with Playwright:
+
+- **Javascript**: [Javascript Selenium Template](https://github.com/wwcode-berlin-hackevenings/selenium-javascript-template)
+- **Python**: [Python Selenium Template](https://github.com/wwcode-berlin-hackevenings/selenium-python-template)
+
+
+Playwright supports more languages, so if your language is not available in one of our templates, check the [docs](https://playwright.dev/docs/languages) and create your own repository. 
+
+
+Follow the instructions in the template repo to setup your local enviroment to be able to run the tests.
+
+**Some additional links:**
+TBD add some helpful links to get started

--- a/frameworks/Selenium.md
+++ b/frameworks/Selenium.md
@@ -1,0 +1,41 @@
+# Selenium
+
+
+## What is Selenium?
+
+[Selenium](https://www.selenium.dev/) is a tool to automate and control browsers 🤖. It's main use case is testing, but it can also be used to automate tasks. It has been around for a long time and has helped countless teams over the years to automate their tests!
+
+The Selenium "family" consists of several different tools to help with the creation and execution of tests, for example an IDE.
+What we will be using for e2e tests is [Selenium Webdriver](https://www.selenium.dev/documentation/webdriver/), a collection of binding for different programming languages that allow us to interact with the browser.
+This means we can use any of the supported programming languages and easily control the browser.
+
+We can then use a testing library  of our choice to check if the results of the browser interaction are as expected.
+
+## Templates for Selenium
+
+The following templates are available for writing e2e tests in different languages, but all using the the Selenium Webdriver to automated the browser.
+
+- **Javascript**: [Javascript Selenium Template](https://github.com/wwcode-berlin-hackevenings/selenium-javascript-template)
+- **Python**: [Python Selenium Template](https://github.com/wwcode-berlin-hackevenings/selenium-python-template)
+
+
+Each template repo also contains links to the Selenium documentation for your language of choice and for the test framework.
+
+
+Follow the instructions in the template repo to setup your local enviroment to be able to run the tests.
+If that does not work, the (Javascript) repo also has a GitHub Action workflow setup to run the tests as an Action.
+This is less fun though, because you don't get to see the browser automation in action!
+
+**Some additional links:**
+- [MDN: Document Query Selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) - how to locate elements inside a website?
+- [Selenium Main Website](https://www.selenium.dev/)
+- [Guide to Browser Manipulation with Selenium](https://www.selenium.dev/documentation/en/webdriver/browser_manipulation/) - examples for different languages
+
+## Selenium basics
+
+TBD
+
+
+## Common pitfalls
+
+TBD


### PR DESCRIPTION
The original idea was to make the workshop as flexible as possible.

To be able to run it for Playwright, I removed all references to Selenium from the main README and extracted the framework specific instructions into a new folder.

I started with a basic setup for Playwright as well, but I also need to create at least one template.